### PR TITLE
fix(SP-2025-1600): Fix publish to pypip

### DIFF
--- a/.github/workflows/05-publish_release.yml
+++ b/.github/workflows/05-publish_release.yml
@@ -6,6 +6,7 @@ on:
 
 env:
   GEMFURY_PUSH_TOKEN: ${{ secrets.GEMFURY_PUSH_TOKEN }}
+  POETRY_PYPI_TOKEN: ${{ secrets.POETRY_PYPI_TOKEN }}
 
 jobs:
   publish_package:


### PR DESCRIPTION
# Pull Request Checklist

This pull request updates the `.github/workflows/05-publish_release.yml` file to include a new environment variable for publishing Python packages.

* [`.github/workflows/05-publish_release.yml`](diffhunk://#diff-efe7a9bb05f5da94f7ff5ee0ccf258769928b4c01be672a7555a42c82e78af03R9): Added the `POETRY_PYPI_TOKEN` environment variable to enable publishing packages to PyPI using Poetry.
- [ ] Did you test manually the changes



